### PR TITLE
add dependabot .yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # `npm` is used for `yarn`
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 100
+    target-branch: "dev"
+


### PR DESCRIPTION
This dependabot `.yml` file is the same as the one in the `zecwallet-mobile` repo.

With its initial settings will open up to 100 reports, so that we can see everything (hopefully) it will report after being turned on at once, rather than having it fill a cue (5 is the default setting) a bit at a time, possibly obscuring which are the most pressing updates. This setting could be 'choked back' later, along with the frequency of the checks (now set to daily).

Additionally, settings in this repo will have to be changed for dependabot to run here:
settings -> code security and analysis -> enable dependabot alerts