### PR TITLE
add openssl legacy flag to yarn build and yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,12 +102,12 @@
   },
   "scripts": {
     "start": "yarn neon && concurrently -k \"cross-env NODE_ENV=production BROWSER=none yarn react-start\" \"wait-on http://localhost:3000 && electronmon .\"",
-    "build": "yarn neon && node scripts/build.js",
+    "build": "yarn neon && node --openssl-legacy-provider scripts/build.js",
     "test": "node scripts/test.js",
     "dist:win": "yarn build && electron-builder -w -c.extraMetadata.main=build/electron.js --publish never",
     "dist:mac": "yarn build && electron-builder -m -c.extraMetadata.main=build/electron.js --publish never",
     "dist:linux": "yarn build && electron-builder -l -c.extraMetadata.main=build/electron.js --publish never",
-    "react-start": "node scripts/start.js",
+    "react-start": "node --openssl-legacy-provider scripts/start.js",
     "neon": "cargo-cp-artifact -nc src/native.node -- cargo build --release --manifest-path native/Cargo.toml --message-format=json-render-diagnostics"
   },
   "eslintConfig": {


### PR DESCRIPTION
fixes #44 : `yarn build` and `yarn start` both failed without these added flags. I believe this may be a problem associated with openssl's interaction with webpack, though that may not be the extent of the problem, see issue.

The following page explains in detail, but the summary is:
"The OpenSSL legacy provider supplies OpenSSL implementations of algorithms that have been deemed legacy. Such algorithms have commonly fallen out of use, have been deemed insecure by the cryptography community, or something similar."
https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html

Thus this may not be a good long-term solution.

I was able to connect to zecwallet-lite over `localhost` with these changes, but additional errors appeared in the browser window.
```ReferenceError: require is not defined
./src/native.node
http://localhost:3000/static/js/main.chunk.js:9546:1
...
```

followed by many more mentions of webpack. This may indicate there is more work to be done before the app is functional with `zingolib/dev` .